### PR TITLE
Revert moved-topic-redirect system

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -650,7 +650,7 @@ SELECT
   (
     SELECT COALESCE(json_agg(sub.*), '{}'::json)
     FROM (
-			SELECT users.uname, arena_outcomes.outcome
+      SELECT users.uname, arena_outcomes.outcome
       FROM arena_outcomes
       JOIN users ON arena_outcomes.user_id = users.id
       WHERE arena_outcomes.topic_id = t.id
@@ -661,8 +661,8 @@ JOIN users u ON t.user_id = u.id
 LEFT JOIN posts p ON t.latest_post_id = p.id
 LEFT JOIN users u2 ON p.user_id = u2.id
 LEFT JOIN forums f ON t.forum_id = f.id
-WHERE (t.forum_id = $1 OR t.moved_from_forum_id = $1)
-ORDER BY is_sticky DESC, COALESCE(t.moved_at, t.latest_post_at) DESC
+WHERE t.forum_id = $1
+ORDER BY is_sticky DESC, t.latest_post_at DESC
 LIMIT $2
 OFFSET $3
   */});
@@ -704,7 +704,7 @@ SELECT
   (
     SELECT COALESCE(json_agg(sub.*), '{}'::json)
     FROM (
-			SELECT users.uname, arena_outcomes.outcome
+      SELECT users.uname, arena_outcomes.outcome
       FROM arena_outcomes
       JOIN users ON arena_outcomes.user_id = users.id
       WHERE arena_outcomes.topic_id = t.id
@@ -715,8 +715,8 @@ JOIN users u ON t.user_id = u.id
 LEFT JOIN posts p ON t.latest_post_id = p.id
 LEFT JOIN users u2 ON p.user_id = u2.id
 LEFT JOIN forums f ON t.forum_id = f.id
-WHERE (t.forum_id = $1 OR t.moved_from_forum_id = $1)
-ORDER BY is_sticky DESC, COALESCE(t.moved_at, t.latest_post_at) DESC
+WHERE t.forum_id = $1
+ORDER BY is_sticky DESC, t.latest_post_at DESC
 LIMIT $2
 OFFSET $3
   */});

--- a/sql/append_log.sql
+++ b/sql/append_log.sql
@@ -1,0 +1,17 @@
+
+------------------------------------------------------------
+-- Put schema changes here as an append-only log that update
+-- SQL seen in schema.sql and functions_and_triggers.sql
+------------------------------------------------------------
+
+--
+-- Prune out old/unused queries
+--
+
+-- Failed indexes for the deimplemented "Topic X was moved to Forum Y"
+-- papertrail system
+DROP INDEX IF EXISTS topics_moved_at_latest_post_at;
+DROP INDEX IF EXISTS topics_sort_1;
+
+-- For show-forum topics ordering
+CREATE INDEX topics_order_crystal ON topics (is_sticky DESC, latest_post_at DESC);

--- a/sql/functions_and_triggers.sql
+++ b/sql/functions_and_triggers.sql
@@ -14,15 +14,6 @@ CREATE UNIQUE INDEX cp_uniq_convoId_userId ON convos_participants (convo_id, use
 CREATE INDEX convos_id_latestPmId_DESC ON convos (id, latest_pm_id DESC);
 CREATE INDEX ON notifications (to_user_id);
 
--- Remove this index, it was replaced by topics_sort_1
-CREATE INDEX topics_moved_at_latest_post_at ON topics (
-  COALESCE(moved_at, latest_post_at) DESC
-);
-
-CREATE INDEX topics_sort_1 ON topics (
-  is_sticky DESC, COALESCE(moved_at, latest_post_at) DESC
-);
-
 -- To fetch a user's most recent rating
 CREATE INDEX ON ratings (created_at DESC);
 CREATE INDEX ON ratings (from_user_id);


### PR DESCRIPTION
This is an intermediate commit to have a simple revert point instead of complicating the code trying to fix the moved-topic-redirect system in the same commit.

More info: http://www.roleplayerguild.com/posts/3025171

Removed 2 old idxs and added back the simple `is_sticky, latest_post_at` idx on topics.

Schema changes:

``` sql
DROP INDEX IF EXISTS topics_moved_at_latest_post_at;
DROP INDEX IF EXISTS topics_sort_1;
CREATE INDEX topics_order_crystal ON topics (is_sticky DESC, latest_post_at DESC);
```

TODO:

- Run `VACUUM ANALYZE` after running schema changes on prod