### PR TITLE
added protocol prefix to non-prefixed urls

### DIFF
--- a/server/bbcode.js
+++ b/server/bbcode.js
@@ -950,6 +950,11 @@ var XBBCODE = (function() {
           myUrl = params.trim().substr(1).trim();
         }
 
+        if (myUrl.indexOf('http') != 0 && myUrl.indexOf('ftp://') != 0){
+          // they don't have a valid protocol at the start, so add one [#63]
+          myUrl = `http://${myUrl}`;
+        }
+
         urlPattern.lastIndex = 0;
         if ( !urlPattern.test( myUrl ) ) {
           hasError.url = true;


### PR DESCRIPTION
This is meant to resolve this issue: #63

I added a check in the bbcode section to add a protocol prefix (http) to the front of a url if it doesn't already have a prefix.  The prefix logic should catch http, https, and ftp (like the URL validation regex).