### PR TITLE
Include active_trophy_id in findPostsByTopicId query

### DIFF
--- a/server/db/index.js
+++ b/server/db/index.js
@@ -973,7 +973,7 @@ exports.findPostsByTopicId = async function(topicId, postType, page) {
         'arena_wins' , u.arena_wins,
         'arena_losses' , u.arena_losses,
         'arena_draws' , u.arena_draws,
-
+        'active_trophy_id' , u.active_trophy_id,
         'has_bio', CASE
             WHEN u.bio_markup IS NULL THEN false
             WHEN char_length(u.bio_markup) > 3 THEN true


### PR DESCRIPTION
Fix Benevolent Cyberpunk fancy userbit and other trophy titles on posts by adding `active_trophy_id` to the list of columns compiled from the `users` table into the JSON object that is created in `server/db/index.js.findPostsByTopicId`