### PR TITLE
Fixed bbcode for Justify

### DIFF
--- a/public/css/general.css
+++ b/public/css/general.css
@@ -378,7 +378,7 @@ blockquote footer {
 .bb-center { text-align: center; }
 .bb-left { text-align: left; }
 .bb-right { text-align: right; }
-.bb-justify { text-align: justify; }
+.bb-justify { text-align: justify; white-space: pre-line}
 
 .bb-quote {
     padding-top: 0;

--- a/server/bbcode.js
+++ b/server/bbcode.js
@@ -682,10 +682,10 @@ var XBBCODE = (function() {
         justify: {
             trimContents: true,
             openTag: function(params, content) {
-                return '<span class="bb-justify">'
+                return '<div class="bb-justify">'
             },
             closeTag: function(params, content) {
-                return '</span>'
+                return '</div>'
             },
         },
         // "large": {


### PR DESCRIPTION
Fixed bbcode for Justify, it had no effect before. Needed to edit the justify tag and the css class it uses. AFAIK, Justify only works on divs, not spans so I made that change (the other text alignment use divs also). I also did some testing and found that the Justify doesn't work when the white space is set to pre-wrap, like the rest of the post. So I made the class for justified text use pre-line whitespace, which should be close enough. If it causes spacing issues, then it should be limited to only text in the Justify tags, which previously had no effect. I did some basic testing with browser tools but wasn't able to get the full guild running locally, but hopefully this change is good.