### PR TITLE
remove pg-extra

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
                 "nodemailer-ses-transport": "1.5.1",
                 "nunjucks": "^3.2.0",
                 "pg": "^8.0.0",
-                "pg-extra": "^3.0.0",
                 "postgres-array": "3.0.4",
                 "prettier": "^3.5.3",
                 "promise.map": "^1.1.2",
@@ -6302,27 +6301,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/clone-deep": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-            "dependencies": {
-                "is-plain-object": "^2.0.4",
-                "kind-of": "^6.0.2",
-                "shallow-clone": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/clone-deep/node_modules/kind-of": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/clone-stats": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
@@ -9114,6 +9092,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
             "dependencies": {
                 "isobject": "^3.0.1"
             },
@@ -9216,6 +9195,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10867,30 +10847,6 @@
             "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
             "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
         },
-        "node_modules/pg-cursor": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.10.0.tgz",
-            "integrity": "sha512-azXIjeIGBwlv/icYyuki5xJYfVSXeirGn4+mvAmYTB8SY0gS1xhluc2CENnq1JrcVSA81lWZgtqc1GAAhH/UuQ==",
-            "peerDependencies": {
-                "pg": "^8"
-            }
-        },
-        "node_modules/pg-extra": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pg-extra/-/pg-extra-3.0.0.tgz",
-            "integrity": "sha512-lZlUy8zg/PoSxWGRbPrFduZfiCSynzMhUkXP5lXkFHCVyk/gSMD5EYtAwbRUD7FFMhZJcnyMlItXl0lYLjGVuA==",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "pg-pool": "^3.6.0",
-                "pg-query-stream": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=7.x"
-            },
-            "peerDependencies": {
-                "pg": ">=7.3"
-            }
-        },
         "node_modules/pg-int8": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -10920,14 +10876,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
             "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
-        },
-        "node_modules/pg-query-stream": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-3.4.2.tgz",
-            "integrity": "sha512-kaTzsi5TQ3XG1KUznEV3MnstM1U4k5Z9cZ02PNmKLMFeYiPEn83FUc2pPVPiKKv93ITI8e5oCh+zEOunjy0ZwQ==",
-            "dependencies": {
-                "pg-cursor": "^2.5.1"
-            }
         },
         "node_modules/pg-types": {
             "version": "2.2.0",
@@ -12145,25 +12093,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
             "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-        },
-        "node_modules/shallow-clone": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-            "dependencies": {
-                "kind-of": "^6.0.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/shallow-clone/node_modules/kind-of": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/sharp": {
             "version": "0.34.2",
@@ -18451,23 +18380,6 @@
             "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
             "dev": true
         },
-        "clone-deep": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-            "requires": {
-                "is-plain-object": "^2.0.4",
-                "kind-of": "^6.0.2",
-                "shallow-clone": "^3.0.0"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "6.0.3",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-                }
-            }
-        },
         "clone-stats": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
@@ -20613,6 +20525,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -20689,7 +20602,8 @@
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+            "dev": true
         },
         "isstream": {
             "version": "0.1.2",
@@ -21971,22 +21885,6 @@
             "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
             "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
         },
-        "pg-cursor": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.10.0.tgz",
-            "integrity": "sha512-azXIjeIGBwlv/icYyuki5xJYfVSXeirGn4+mvAmYTB8SY0gS1xhluc2CENnq1JrcVSA81lWZgtqc1GAAhH/UuQ==",
-            "requires": {}
-        },
-        "pg-extra": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pg-extra/-/pg-extra-3.0.0.tgz",
-            "integrity": "sha512-lZlUy8zg/PoSxWGRbPrFduZfiCSynzMhUkXP5lXkFHCVyk/gSMD5EYtAwbRUD7FFMhZJcnyMlItXl0lYLjGVuA==",
-            "requires": {
-                "clone-deep": "^4.0.1",
-                "pg-pool": "^3.6.0",
-                "pg-query-stream": "^3.0.0"
-            }
-        },
         "pg-int8": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -22008,14 +21906,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
             "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
-        },
-        "pg-query-stream": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-3.4.2.tgz",
-            "integrity": "sha512-kaTzsi5TQ3XG1KUznEV3MnstM1U4k5Z9cZ02PNmKLMFeYiPEn83FUc2pPVPiKKv93ITI8e5oCh+zEOunjy0ZwQ==",
-            "requires": {
-                "pg-cursor": "^2.5.1"
-            }
         },
         "pg-types": {
             "version": "2.2.0",
@@ -23025,21 +22915,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
             "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-        },
-        "shallow-clone": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-            "requires": {
-                "kind-of": "^6.0.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "6.0.3",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-                }
-            }
         },
         "sharp": {
             "version": "0.34.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
         "nodemailer-ses-transport": "1.5.1",
         "nunjucks": "^3.2.0",
         "pg": "^8.0.0",
-        "pg-extra": "^3.0.0",
         "postgres-array": "3.0.4",
         "prettier": "^3.5.3",
         "promise.map": "^1.1.2",

--- a/server/belt.ts
+++ b/server/belt.ts
@@ -57,6 +57,16 @@ type TimeSpan = {
     milliseconds?: number
 }
 
+function timespanToMilliseconds(span: TimeSpan): number {
+    return ((span.years || 0) * 1000 * 60 * 60 * 24 * 365 +
+            (span.months || 0) * 1000 * 60 * 60 * 24 * 30 +
+            (span.days || 0) * 1000 * 60 * 60 * 24 +
+            (span.hours || 0) * 1000 * 60 * 60 +
+            (span.minutes || 0) * 1000 * 60 +
+            (span.seconds || 0) * 1000 +
+            (span.milliseconds || 0))
+}
+
 export function pastDate(opts: TimeSpan): Date
 export function pastDate(nowDate: Date, opts: TimeSpan): Date
 
@@ -75,14 +85,7 @@ export function pastDate(nowDateOrOpts: Date | TimeSpan, opts?: TimeSpan): Date 
     }
 
     return new Date(
-        nowDate.getTime() -
-            ((span.years || 0) * 1000 * 60 * 60 * 24 * 365 +
-                (span.months || 0) * 1000 * 60 * 60 * 24 * 30 +
-                (span.days || 0) * 1000 * 60 * 60 * 24 +
-                (span.hours || 0) * 1000 * 60 * 60 +
-                (span.minutes || 0) * 1000 * 60 +
-                (span.seconds || 0) * 1000 +
-                (span.milliseconds || 0))
+        nowDate.getTime() - timespanToMilliseconds(span)
     )
 }
 
@@ -104,14 +107,7 @@ export function futureDate(nowDateOrOpts: Date | TimeSpan, opts?: TimeSpan): Dat
     }
 
     return new Date(
-        nowDate.getTime() +
-            (span.years || 0) * 1000 * 60 * 60 * 24 * 365 +
-            (span.months || 0) * 1000 * 60 * 60 * 24 * 30 +
-            (span.days || 0) * 1000 * 60 * 60 * 24 +
-            (span.hours || 0) * 1000 * 60 * 60 +
-            (span.minutes || 0) * 1000 * 60 +
-            (span.seconds || 0) * 1000 +
-            (span.milliseconds || 0)
+        nowDate.getTime() + timespanToMilliseconds(span)
     )
 }
 
@@ -176,7 +172,7 @@ export const joinErrors = function(errObj) {
 // Authentication
 ////////////////////////////////////////////////////////////
 
-export const hashPassword = password => {
+export const hashPassword = (password: string) => {
     return bcrypt.hash(password, 10)
 }
 
@@ -286,10 +282,11 @@ export const slugify = function(...args: (string | number)[]) {
     )
 }
 
+// This relies on parseInt("123-a-b-c") parse 123
 // Returns Int | null
-export const extractId = function(slug) {
-    var n = parseInt(slug, 10)
-    return _.isNaN(n) ? null : n
+export function extractId(slug: string): number | null {
+    const n = parseInt(slug, 10)
+    return isNaN(n) ? null : n
 }
 
 ////////////////////////////////////////////////////////////

--- a/server/belt.ts
+++ b/server/belt.ts
@@ -242,8 +242,8 @@ export const isDBClient = function(obj) {
     )
 }
 
-export const slugifyUname = function(uname) {
-    var slug = uname
+export function slugifyUname(uname: string): string {
+    const slug = uname
         .trim()
         .toLowerCase()
         .replace(/ /g, '-')
@@ -296,7 +296,7 @@ export function extractId(slug: string): number | null {
 export const extractMentions = function(str, unameToReject) {
     var start = Date.now()
     debug('[extractMentions]')
-    var unames: Record<string, boolean> = {}
+    var unames: Record<string, boolean> = Object.create(null)
     var re = /\[(quote)[^\]]*\]|\[(\/quote)\]|\[@([a-z0-9_\- ]+)\]/gi
     var quoteStack: string[] = []
 

--- a/server/cache.ts
+++ b/server/cache.ts
@@ -105,12 +105,13 @@ const cache = new IntervalCache()
         []
     )
 
-if (config.LATEST_RPGN_TOPIC_ID) {
+if (typeof config.LATEST_RPGN_TOPIC_ID === 'number') {
+    const id = config.LATEST_RPGN_TOPIC_ID
     cache.every(
         'latest-rpgn-topic',
         1000 * 60,
         () => {
-            return db.findRGNTopicForHomepage(config.LATEST_RPGN_TOPIC_ID)
+            return db.findRGNTopicForHomepage(id)
         },
         null
     )

--- a/server/db/admin.ts
+++ b/server/db/admin.ts
@@ -1,6 +1,5 @@
 // 3rd
 import assert from 'assert'
-import { sql } from 'pg-extra'
 // import Knex from 'knex'
 // const knex = Knex({ client: 'pg' })
 // 1st
@@ -16,86 +15,86 @@ export const mergeUsers = async ({ mainId, huskId }) => {
 
     return pool.withTransaction(async client => {
         // Move topics
-        await client.query(sql`
+        await client.query(`
       UPDATE topics
-      SET user_id = ${mainId}
-      WHERE user_id = ${huskId}
-    `)
+      SET user_id = $1
+      WHERE user_id = $2
+    `, [mainId, huskId])
         // Move posts
-        await client.query(sql`
+        await client.query(`
       UPDATE posts
-      SET user_id = ${mainId}
-      WHERE user_id = ${huskId}
-    `)
+      SET user_id = $1
+      WHERE user_id = $2
+    `, [mainId, huskId])
         // Move post_revs
-        await client.query(sql`
+        await client.query(`
       UPDATE post_revs
-      SET user_id = ${mainId}
-      WHERE user_id = ${huskId}
-    `)
+      SET user_id = $1
+      WHERE user_id = $2
+    `, [mainId, huskId])
         // Move topic_subscriptions
         // unique(user_id, topic_id)
-        await client.query(sql`
+        await client.query(`
       UPDATE topic_subscriptions
-      SET user_id = ${mainId}
-      WHERE user_id = ${huskId}
+      SET user_id = $1
+      WHERE user_id = $2
         AND topic_id NOT IN (
           SELECT topic_id FROM topic_subscriptions
-          WHERE user_id = ${mainId}
+          WHERE user_id = $1
         )
-    `)
+    `, [mainId, huskId])
         // Move convos
-        await client.query(sql`
+        await client.query(`
       UPDATE convos
-      SET user_id = ${mainId}
-      WHERE user_id = ${huskId}
-    `)
+      SET user_id = $1
+      WHERE user_id = $2
+    `, [mainId, huskId])
         // Move PMs
-        await client.query(sql`
+        await client.query(`
       UPDATE pms
-      SET user_id = ${mainId}
-      WHERE user_id = ${huskId}
-    `)
+      SET user_id = $1
+      WHERE user_id = $2
+    `, [mainId, huskId])
         // Move convos_participants
         // unique(user_id, convo_id)
-        await client.query(sql`
+        await client.query(`
       UPDATE convos_participants
-      SET user_id = ${mainId}
-      WHERE user_id = ${huskId}
+      SET user_id = $1
+      WHERE user_id = $2
         AND convo_id NOT IN (
           SELECT convo_id FROM convos_participants
-          WHERE user_id = ${mainId}
+          WHERE user_id = $1
         )
-    `)
+    `, [mainId, huskId])
         // Move albums
-        await client.query(sql`
+        await client.query(`
       UPDATE albums
-      SET user_id = ${mainId}
-      WHERE user_id = ${huskId}
-    `)
+      SET user_id = $1
+      WHERE user_id = $2
+    `, [mainId, huskId])
         // Move images
-        await client.query(sql`
+        await client.query(`
       UPDATE images
-      SET user_id = ${mainId}
-      WHERE user_id = ${huskId}
-    `)
+      SET user_id = $1
+      WHERE user_id = $2
+    `, [mainId, huskId])
         // Move topic_bans
-        await client.query(sql`
+        await client.query(`
       UPDATE topic_bans
-      SET banned_by_id = ${mainId}
-      WHERE banned_by_id = ${huskId}
-    `)
+      SET banned_by_id = $1
+      WHERE banned_by_id = $2
+    `, [mainId, huskId])
         // Move forum mods
         // unique(forum_id, user_id)
-        await client.query(sql`
+        await client.query(`
       UPDATE forum_mods
-      SET user_id = ${mainId}
-      WHERE user_id = ${huskId}
+      SET user_id = $1
+      WHERE user_id = $2
         AND forum_id NOT IN (
           SELECT forum_id FROM forum_mods
-          WHERE user_id = ${mainId}
+          WHERE user_id = $1
         )
-    `)
+    `, [mainId, huskId])
 
         // Do nothing with statuses
         // Do nothing with ratings
@@ -111,7 +110,7 @@ export const mergeUsers = async ({ mainId, huskId }) => {
         // - posts_count
         // - pms_count
         // - TODO: trophy_count (after moving trophies)
-        await client.query(sql`
+        await client.query(`
       UPDATE users
       SET posts_count = sub.posts_count
         , pms_count = sub.pms_count
@@ -121,10 +120,10 @@ export const mergeUsers = async ({ mainId, huskId }) => {
           (SELECT COUNT(id) FROM posts WHERE user_id = users.id) posts_count,
           (SELECT COUNT(id) FROM pms WHERE user_id = users.id) pms_count
         FROM users
-        WHERE id IN (${mainId}, ${huskId})
+        WHERE id IN ($1, $2)
       ) sub
       WHERE users.id = sub.id
-    `)
+    `, [mainId, huskId])
     })
 }
 
@@ -150,14 +149,13 @@ export const createGuildUpdateNotifications = async (postId, blurb) => {
     // - only members
     // - only people that logged in recently
     const userIds = await pool
-        .many(
-            sql`
+        .query(`
     SELECT id
     FROM users
     WHERE role = 'member'
       AND last_online_at > NOW() - '3 months'::interval
-  `
-        )
+  `)
+        .then(res => res.rows)
         .then(xs => xs.map(x => x.id))
 
     console.log(`[guild-update] notifying ${userIds.length} users...`)
@@ -166,17 +164,15 @@ export const createGuildUpdateNotifications = async (postId, blurb) => {
     const metas = userIds.map(() => meta)
 
     return pool
-        .query(
-            sql`
+        .query(`
     INSERT INTO notifications (type, from_user_id, post_id, to_user_id, meta)
     SELECT
       'GUILD_UPDATE', 1, post_id, to_user_id, meta
     FROM unnest(
-        ${postIds}::int[],
-        ${userIds}::int[],
-        ${metas}::json[]
+        $1::int[],
+        $2::int[],
+        $3::json[]
     ) as sub (post_id, to_user_id, meta)
-  `
-        )
+  `, [postIds, userIds, metas])
         .then(res => res.rowCount)
 }

--- a/server/db/chat.ts
+++ b/server/db/chat.ts
@@ -3,13 +3,12 @@
 import assert from 'assert'
 // 1st
 import { pool } from './util'
-import { sql } from 'pg-extra'
 
 ////////////////////////////////////////////////////////////
 
 // Returns [{when: '2015-7-25', count: 64}, ...]
 export const getChatLogDays = async function() {
-    return pool.many(sql`
+    return pool.query(`
     SELECT to_char(sub.day, 'YYYY-MM-DD') "when", sub.count "count"
     FROM (
       SELECT date_trunc('day', cm.created_at) "day", COUNT(cm.*) "count"
@@ -17,7 +16,7 @@ export const getChatLogDays = async function() {
       GROUP BY "day"
       ORDER BY "day"
     ) sub
-  `)
+  `).then(res => res.rows)
 }
 
 ////////////////////////////////////////////////////////////
@@ -25,7 +24,7 @@ export const getChatLogDays = async function() {
 // `when` is string 'YYYY-MM-DD'
 export const findLogByDateTrunc = async function(when) {
     assert(typeof when === 'string')
-    return pool.many(sql`
+    return pool.query(`
     SELECT sub.*
     FROM (
       SELECT
@@ -35,7 +34,7 @@ export const findLogByDateTrunc = async function(when) {
       FROM chat_messages cm
       LEFT OUTER JOIN users u ON cm.user_id = u.id
     ) sub
-    WHERE sub.when = ${when}
+    WHERE sub.when = $1
     ORDER BY sub.id
-  `)
+  `, [when]).then(res => res.rows)
 }

--- a/server/db/hits.ts
+++ b/server/db/hits.ts
@@ -176,11 +176,11 @@ export const findAltsFromUserId = async userId => {
   `, [userId]).then(res => res.rows)
 
     // mapping of user_id -> {user: {...}, matches: {'TRACK': Date, 'IP_ADDRESS': Date, ...]}
-    const map = {}
+    const map: Record<string, { matches: Record<string, Date>, user: any }> = Object.create(null)
 
     rows.forEach(row => {
         if (map[row.user.uname]) {
-            map[row.user.uname].matches[row.match] = row.latest_match_at
+            map[row.user.uname]!.matches[row.match] = row.latest_match_at
         } else {
             map[row.user.uname] = {
                 matches: { [row.match]: row.latest_match_at },

--- a/server/db/profile-views.ts
+++ b/server/db/profile-views.ts
@@ -4,32 +4,31 @@
 import assert from 'assert'
 // 1st
 import { pool } from './util.js'
-import { sql } from 'pg-extra'
 
 ////////////////////////////////////////////////////////////
 
 export const insertView = async function(viewerId, viewedId) {
     assert(Number.isInteger(viewerId))
     assert(Number.isInteger(viewedId))
-    return pool.query(sql`
+    return pool.query(`
     INSERT INTO profile_views (viewer_id, viewed_id)
-    VALUES (${viewerId}, ${viewedId})
-  `)
+    VALUES ($1, $2)
+  `, [viewerId, viewedId])
 }
 
 export const getLatestViews = async function(viewedId) {
     assert(Number.isInteger(viewedId))
 
-    return pool.many(sql`
+    return pool.query(`
     SELECT viewers.uname
           , viewers.slug
           , viewers.avatar_url
           , MAX(pv.created_at) as "maxstamp"
     FROM profile_views pv
     JOIN users viewers ON pv.viewer_id = viewers.id
-    WHERE pv.viewed_id = ${viewedId}
+    WHERE pv.viewed_id = $1
     GROUP BY viewers.uname, viewers.slug, viewers.avatar_url
     ORDER BY maxstamp DESC
     LIMIT 10
- `)
+ `, [viewedId]).then(res => res.rows)
 }

--- a/server/db/users.ts
+++ b/server/db/users.ts
@@ -7,7 +7,6 @@ const knex = Knex({ client: 'pg' })
 import _ from 'lodash'
 // 1st
 import { pool } from './util.js'
-import { sql } from 'pg-extra'
 
 // Note: The db/*.js files are an ongoing effort to
 // split apart the db/index.js monolith.
@@ -48,12 +47,12 @@ export const updateUser = async function(userId, fields) {
 export const unapproveUser = async userId => {
     assert(Number.isInteger(userId))
 
-    return pool.query(sql`
+    return pool.query(`
     UPDATE users
     SET approved_by_id = NULL,
         approved_at = NULL
-    WHERE id = ${userId}
-  `)
+    WHERE id = $1
+  `, [userId])
 }
 
 ////////////////////////////////////////////////////////////
@@ -62,12 +61,12 @@ export const approveUser = async ({ approvedBy, targetUser }) => {
     assert(Number.isInteger(approvedBy))
     assert(Number.isInteger(targetUser))
 
-    return pool.query(sql`
+    return pool.query(`
     UPDATE users
-    SET approved_by_id = ${approvedBy},
+    SET approved_by_id = $1,
         approved_at = NOW()
-    WHERE id = ${targetUser}
-  `)
+    WHERE id = $2
+  `, [approvedBy, targetUser])
 }
 
 ////////////////////////////////////////////////////////////

--- a/server/db/vms.ts
+++ b/server/db/vms.ts
@@ -1,42 +1,41 @@
-import { pool } from './util.js'
-import { sql } from 'pg-extra'
+import { pool, maybeOneRow } from './util.js'
 
 ////////////////////////////////////////////////////////////
 
 export const getVmById = async id => {
-    return pool.one(sql`
+    return pool.query(`
     SELECT
       vms.*,
       (SELECT to_json(users.*) FROM users WHERE id = vms.to_user_id) to_user,
       (SELECT to_json(users.*) FROM users WHERE id = vms.from_user_id) from_user
     FROM vms
-    WHERE id = ${id}
-  `)
+    WHERE id = $1
+  `, [id]).then(maybeOneRow)
 }
 
 ////////////////////////////////////////////////////////////
 
 export const deleteVm = async id => {
-    return pool.query(sql`
+    return pool.query(`
     DELETE FROM vms
-    WHERE id = ${id}
-  `)
+    WHERE id = $1
+  `, [id])
 }
 
 ////////////////////////////////////////////////////////////
 
 export const deleteVmChildren = async parentId => {
-    return pool.query(sql`
+    return pool.query(`
     DELETE FROM vms
-    WHERE parent_vm_id = ${parentId}
-  `)
+    WHERE parent_vm_id = $1
+  `, [parentId])
 }
 
 ////////////////////////////////////////////////////////////
 
 export const deleteNotificationsForVmId = async id => {
-    return pool.query(sql`
+    return pool.query(`
     DELETE FROM notifications
-    WHERE id = ${id}
-  `)
+    WHERE id = $1
+  `, [id])
 }

--- a/server/db/vms.ts
+++ b/server/db/vms.ts
@@ -36,6 +36,6 @@ export const deleteVmChildren = async parentId => {
 export const deleteNotificationsForVmId = async id => {
     return pool.query(`
     DELETE FROM notifications
-    WHERE id = $1
+    WHERE vm_id = $1
   `, [id])
 }

--- a/server/guildbot.ts
+++ b/server/guildbot.ts
@@ -1,10 +1,9 @@
 // 3rd
 import Discord from 'discord.js'
-import { sql } from 'pg-extra'
 // 1st
 import * as config from './config'
 import * as dice from './dice'
-import { getClient } from './db/util'
+import { exactlyOneRow, getClient } from './db/util'
 
 function timeout(ms: number) {
     return new Promise(resolve => setTimeout(resolve, ms))
@@ -28,9 +27,11 @@ export default {
         const client = getClient()
         client.connect()
 
-        const { lock } = await client.one(
-            sql`SELECT pg_try_advisory_lock(1337) "lock"`
-        )
+        const { lock } = await client
+            .query<{ lock: boolean }>(
+                `SELECT pg_try_advisory_lock(1337) "lock"`
+            )
+            .then(exactlyOneRow)
 
         if (!lock) {
             // Release the losing clients

--- a/server/index.ts
+++ b/server/index.ts
@@ -429,6 +429,7 @@ router.get('/me/edit', async (ctx: Context) => {
 
 router.post('/topics/:topicSlug/co-gms', async (ctx: Context) => {
     var topicId = belt.extractId(ctx.params.topicSlug)
+    ctx.assert(topicId, 404)
     var topic = await db.findTopicById(topicId).then(pre.presentTopic)
     ctx.assert(topic, 404)
     ctx.assertAuthorized(ctx.currUser, 'UPDATE_TOPIC_CO_GMS', topic)
@@ -464,6 +465,7 @@ router.post('/topics/:topicSlug/co-gms', async (ctx: Context) => {
 
 router.delete('/topics/:topicSlug/co-gms/:userSlug', async (ctx: Context) => {
     var topicId = belt.extractId(ctx.params.topicSlug)
+    ctx.assert(topicId, 404)
     var topic = await db.findTopicById(topicId).then(pre.presentTopic)
     ctx.assert(topic, 404)
     ctx.assertAuthorized(ctx.currUser, 'UPDATE_TOPIC_CO_GMS', topic)
@@ -1811,6 +1813,7 @@ router.get('/pms/:id', async (ctx: Context) => {
 // Body { uname: String }
 router.post('/topics/:slug/bans', async (ctx: Context) => {
     const topicId = belt.extractId(ctx.params.slug)
+    ctx.assert(topicId, 404)
     const topic = await db.findTopicById(topicId).then(pre.presentTopic)
     ctx.assert(topic, 404)
     ctx.assertAuthorized(ctx.currUser, 'UPDATE_TOPIC', topic)
@@ -2264,6 +2267,7 @@ router.get('/me/notifications', async (ctx: Context) => {
 //
 router.post('/topics/:slug/move', async (ctx: Context) => {
     const topicId = belt.extractId(ctx.params.slug)
+    ctx.assert(topicId, 404)
     let topic = await db.findTopicById(topicId).then(pre.presentTopic)
     ctx.assert(topic, 404)
     ctx.assertAuthorized(ctx.currUser, 'MOVE_TOPIC', topic)

--- a/server/index.ts
+++ b/server/index.ts
@@ -102,6 +102,7 @@ import services from './services'
 import cache2 from './cache2'
 import makeAgo from './ago'
 import protectCsrf from './middleware/protect-csrf'
+import { pool } from './db/util'
 
 app.use(middleware.methodOverride())
 
@@ -592,7 +593,7 @@ router.post('/sessions', async (ctx: Context) => {
     )
 
     // User authenticated
-    var session = await db.createSession({
+    var session = await db.createSession(pool, {
         userId: user.id,
         ipAddress: ctx.request.ip,
         interval: ctx.vals['remember-me'] ? '1 year' : '2 weeks',
@@ -874,7 +875,7 @@ router.post('/reset-password', async (ctx: Context) => {
 
     // Log the user in
     var interval = rememberMe ? '1 year' : '1 day'
-    var session = await db.createSession({
+    var session = await db.createSession(pool, {
         userId: user.id,
         ipAddress: ctx.request.ip,
         interval: interval,

--- a/server/middleware/index.ts
+++ b/server/middleware/index.ts
@@ -28,9 +28,9 @@ export const currUser = function() {
 
 // Expose req.flash (getter) and res.flash = _ (setter)
 // Flash data persists in user's sessions until the next ~successful response
-export const flash = function(cookieName = 'flash') {
+export function flash(cookieName = 'flash') {
     return async (ctx: Context, next: Next) => {
-        let data = {}
+        let data = Object.create(null)
 
         if (ctx.cookies.get(cookieName)) {
             try {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -13,7 +13,6 @@ import * as cancan from '../cancan'
 import * as db from '../db'
 import cache2 from '../cache2'
 import * as pre from '../presenters'
-// import { sql, _raw } from 'pg-extra'
 import { pool } from '../db/util.js'
 import { Context } from 'koa'
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -2,9 +2,9 @@
 // 3rd
 import assert from 'assert'
 import Router from '@koa/router'
+import Knex from 'knex'
 // import createDebug from 'debug'
 // const debug = createDebug('app:routes:index')
-import { sql, _raw } from 'pg-extra'
 import _ from 'lodash'
 import nodeUrl from 'url'
 // 1st
@@ -13,8 +13,13 @@ import * as cancan from '../cancan'
 import * as db from '../db'
 import cache2 from '../cache2'
 import * as pre from '../presenters'
+// import { sql, _raw } from 'pg-extra'
 import { pool } from '../db/util.js'
 import { Context } from 'koa'
+
+const knex = Knex({
+    client: 'pg',
+})
 
 ////////////////////////////////////////////////////////////
 
@@ -35,128 +40,210 @@ router.get('/faq', async (ctx: Context) => {
 
 ////////////////////////////////////////////////////////////
 
-async function listRoleplays(logic, sort, selectedTagIds = [], beforeId) {
+// async function listRoleplays_OLD(logic, sort, selectedTagIds = [], beforeId) {
+//     assert(['any', 'all'].includes(logic))
+//     assert(['bumped', 'created'].includes(sort))
+//     assert(Array.isArray(selectedTagIds))
+//     assert(typeof beforeId === 'undefined' || Number.isInteger(beforeId))
+
+//     const perPage = 20
+
+//     return pool.many(
+//         sql`
+//     SELECT
+//       t.*,
+//       to_json(f.*) "forum",
+//       json_build_object(
+//         'uname', u.uname,
+//         'slug', u.slug
+//       ) "user",
+//       CASE
+//         WHEN ic_posts IS NULL THEN NULL
+//         ELSE json_build_object(
+//           'id', ic_posts.id,
+//           'created_at', ic_posts.created_at
+//         )
+//       END "latest_ic_post",
+//       CASE
+//         WHEN ic_users IS NULL THEN NULL
+//         ELSE json_build_object(
+//         'uname', ic_users.uname,
+//         'slug', ic_users.slug
+//         )
+//       END "latest_ic_user",
+//       CASE
+//         WHEN ooc_posts IS NULL THEN NULL
+//         ELSE json_build_object(
+//           'id', ooc_posts.id,
+//           'created_at', ooc_posts.created_at
+//         )
+//       END "latest_ooc_post",
+//       CASE
+//         WHEN ooc_users IS NULL THEN NULL
+//         ELSE json_build_object(
+//         'uname', ooc_users.uname,
+//         'slug', ooc_users.slug
+//         )
+//       END "latest_ooc_user",
+//       CASE
+//         WHEN char_posts IS NULL THEN NULL
+//         ELSE json_build_object(
+//           'id', char_posts.id,
+//           'created_at', char_posts.created_at
+//         )
+//       END "latest_char_post",
+//       CASE
+//         WHEN char_users IS NULL THEN NULL
+//         ELSE json_build_object(
+//         'uname', char_users.uname,
+//         'slug', char_users.slug
+//         )
+//       END "latest_char_user",
+//       (
+//         SELECT json_agg(tags.*)
+//         FROM tags
+//         JOIN tags_topics ON tags.id = tags_topics.tag_id
+//         JOIN topics ON tags_topics.topic_id = topics.id
+//         WHERE topics.id = t.id
+//       ) "tags"
+//     FROM (
+//       SELECT topics.*
+//       FROM topics
+//       , LATERAL (
+//           SELECT array_agg(tt.tag_id) "tag_ids"
+//           FROM tags_topics tt
+//           WHERE topics.id = tt.topic_id
+//           GROUP BY topics.id
+//       ) s
+//       JOIN tags ON tags.id = ANY (s.tag_ids)
+//       WHERE topics.forum_id IN (3, 4, 5, 6, 7, 42, 39)
+//         AND topics.is_hidden = false
+//     `
+//             .append(
+//                 beforeId
+//                     ? sort === 'created'
+//                       ? sql`AND topics.id < ${beforeId}`
+//                       : sql`AND topics.latest_post_id < ${beforeId}`
+//                     : _raw``
+//             )
+//             .append(
+//                 selectedTagIds.length > 0
+//                     ? logic === 'any'
+//                       ? sql`AND tags.id = ANY (${selectedTagIds})`
+//                       : sql`AND ${selectedTagIds} <@ s.tag_ids`
+//                     : _raw``
+//             )
+//             .append(sql`GROUP BY topics.id`)
+//             .append(
+//                 sort === 'created'
+//                     ? sql`ORDER BY topics.created_at DESC`
+//                     : sql`ORDER BY topics.latest_post_id DESC`
+//             )
+//             .append(
+//                 sql`
+//         LIMIT ${perPage}
+//       ) t
+//       JOIN users u ON t.user_id = u.id
+//       JOIN forums f ON t.forum_id = f.id
+//       JOIN posts latest_post ON t.latest_post_id = latest_post.id
+//       JOIN users u2 ON latest_post.user_id = u2.id
+//       LEFT OUTER JOIN posts ic_posts ON t.latest_ic_post_id = ic_posts.id
+//       LEFT OUTER JOIN users ic_users ON ic_posts.user_id = ic_users.id
+//       LEFT OUTER JOIN posts ooc_posts ON t.latest_ooc_post_id = ooc_posts.id
+//       LEFT OUTER JOIN users ooc_users ON ooc_posts.user_id = ooc_users.id
+//       LEFT OUTER JOIN posts char_posts ON t.latest_char_post_id = char_posts.id
+//       LEFT OUTER JOIN users char_users ON char_posts.user_id = char_users.id
+//     `
+//             )
+//             .append(
+//                 sort === 'created'
+//                     ? sql`ORDER BY t.created_at DESC`
+//                     : sql`ORDER BY t.latest_post_id DESC`
+//             )
+//             .append(sql`LIMIT ${perPage}`)
+//     )
+// }
+
+async function listRoleplays(logic: 'any' | 'all', sort: 'created' | 'bumped', selectedTagIds: number[] = [], beforeId: number | null) {
     assert(['any', 'all'].includes(logic))
-    assert(['bumped', 'created'].includes(sort))
+    assert(['created', 'bumped'].includes(sort))
     assert(Array.isArray(selectedTagIds))
     assert(typeof beforeId === 'undefined' || Number.isInteger(beforeId))
-
+    
     const perPage = 20
-
-    return pool.many(
-        sql`
-    SELECT
-      t.*,
-      to_json(f.*) "forum",
-      json_build_object(
-        'uname', u.uname,
-        'slug', u.slug
-      ) "user",
-      CASE
-        WHEN ic_posts IS NULL THEN NULL
-        ELSE json_build_object(
-          'id', ic_posts.id,
-          'created_at', ic_posts.created_at
+    
+    const subquery = knex('topics')
+        .select('topics.*')
+        .from(knex.raw('topics, LATERAL (SELECT array_agg(tt.tag_id) "tag_ids" FROM tags_topics tt WHERE topics.id = tt.topic_id GROUP BY topics.id) s'))
+        .join('tags', knex.raw('tags.id = ANY (s.tag_ids)'))
+        .whereIn('topics.forum_id', [3, 4, 5, 6, 7, 42, 39])
+        .where('topics.is_hidden', false)
+    
+    // Dynamic WHERE clauses
+    if (beforeId) {
+        if (sort === 'created') {
+            subquery.where('topics.id', '<', beforeId)
+        } else {
+            subquery.where('topics.latest_post_id', '<', beforeId)
+        }
+    }
+    
+    if (selectedTagIds.length > 0) {
+        if (logic === 'any') {
+            subquery.whereRaw('tags.id = ANY (?)', [selectedTagIds])
+        } else {
+            subquery.whereRaw('? <@ s.tag_ids', [selectedTagIds])
+        }
+    }
+    
+    subquery.groupBy('topics.id')
+    
+    // Dynamic ORDER BY
+    if (sort === 'created') {
+        subquery.orderBy('topics.created_at', 'desc')
+    } else {
+        subquery.orderBy('topics.latest_post_id', 'desc')
+    }
+    
+    subquery.limit(perPage)
+    
+    // Main query
+    const query = knex
+        .with('t', subquery)
+        .select(
+            't.*',
+            knex.raw('to_json(f.*) as forum'),
+            knex.raw(`json_build_object('uname', u.uname, 'slug', u.slug) as user`),
+            // ... all the other CASE statements
+            knex.raw(`(
+                SELECT json_agg(tags.*)
+                FROM tags
+                JOIN tags_topics ON tags.id = tags_topics.tag_id
+                JOIN topics ON tags_topics.topic_id = topics.id
+                WHERE topics.id = t.id
+            ) as tags`)
         )
-      END "latest_ic_post",
-      CASE
-        WHEN ic_users IS NULL THEN NULL
-        ELSE json_build_object(
-        'uname', ic_users.uname,
-        'slug', ic_users.slug
-        )
-      END "latest_ic_user",
-      CASE
-        WHEN ooc_posts IS NULL THEN NULL
-        ELSE json_build_object(
-          'id', ooc_posts.id,
-          'created_at', ooc_posts.created_at
-        )
-      END "latest_ooc_post",
-      CASE
-        WHEN ooc_users IS NULL THEN NULL
-        ELSE json_build_object(
-        'uname', ooc_users.uname,
-        'slug', ooc_users.slug
-        )
-      END "latest_ooc_user",
-      CASE
-        WHEN char_posts IS NULL THEN NULL
-        ELSE json_build_object(
-          'id', char_posts.id,
-          'created_at', char_posts.created_at
-        )
-      END "latest_char_post",
-      CASE
-        WHEN char_users IS NULL THEN NULL
-        ELSE json_build_object(
-        'uname', char_users.uname,
-        'slug', char_users.slug
-        )
-      END "latest_char_user",
-      (
-        SELECT json_agg(tags.*)
-        FROM tags
-        JOIN tags_topics ON tags.id = tags_topics.tag_id
-        JOIN topics ON tags_topics.topic_id = topics.id
-        WHERE topics.id = t.id
-      ) "tags"
-    FROM (
-      SELECT topics.*
-      FROM topics
-      , LATERAL (
-          SELECT array_agg(tt.tag_id) "tag_ids"
-          FROM tags_topics tt
-          WHERE topics.id = tt.topic_id
-          GROUP BY topics.id
-      ) s
-      JOIN tags ON tags.id = ANY (s.tag_ids)
-      WHERE topics.forum_id IN (3, 4, 5, 6, 7, 42, 39)
-        AND topics.is_hidden = false
-    `
-            .append(
-                beforeId
-                    ? sort === 'created'
-                      ? sql`AND topics.id < ${beforeId}`
-                      : sql`AND topics.latest_post_id < ${beforeId}`
-                    : _raw``
-            )
-            .append(
-                selectedTagIds.length > 0
-                    ? logic === 'any'
-                      ? sql`AND tags.id = ANY (${selectedTagIds})`
-                      : sql`AND ${selectedTagIds} <@ s.tag_ids`
-                    : _raw``
-            )
-            .append(sql`GROUP BY topics.id`)
-            .append(
-                sort === 'created'
-                    ? sql`ORDER BY topics.created_at DESC`
-                    : sql`ORDER BY topics.latest_post_id DESC`
-            )
-            .append(
-                sql`
-        LIMIT ${perPage}
-      ) t
-      JOIN users u ON t.user_id = u.id
-      JOIN forums f ON t.forum_id = f.id
-      JOIN posts latest_post ON t.latest_post_id = latest_post.id
-      JOIN users u2 ON latest_post.user_id = u2.id
-      LEFT OUTER JOIN posts ic_posts ON t.latest_ic_post_id = ic_posts.id
-      LEFT OUTER JOIN users ic_users ON ic_posts.user_id = ic_users.id
-      LEFT OUTER JOIN posts ooc_posts ON t.latest_ooc_post_id = ooc_posts.id
-      LEFT OUTER JOIN users ooc_users ON ooc_posts.user_id = ooc_users.id
-      LEFT OUTER JOIN posts char_posts ON t.latest_char_post_id = char_posts.id
-      LEFT OUTER JOIN users char_users ON char_posts.user_id = char_users.id
-    `
-            )
-            .append(
-                sort === 'created'
-                    ? sql`ORDER BY t.created_at DESC`
-                    : sql`ORDER BY t.latest_post_id DESC`
-            )
-            .append(sql`LIMIT ${perPage}`)
-    )
+        .from('t')
+        .join('users as u', 't.user_id', 'u.id')
+        .join('forums as f', 't.forum_id', 'f.id')
+        .join('posts as latest_post', 't.latest_post_id', 'latest_post.id')
+        .join('users as u2', 'latest_post.user_id', 'u2.id')
+        .leftJoin('posts as ic_posts', 't.latest_ic_post_id', 'ic_posts.id')
+        .leftJoin('users as ic_users', 'ic_posts.user_id', 'ic_users.id')
+        .leftJoin('posts as ooc_posts', 't.latest_ooc_post_id', 'ooc_posts.id')
+        .leftJoin('users as ooc_users', 'ooc_posts.user_id', 'ooc_users.id')
+        .leftJoin('posts as char_posts', 't.latest_char_post_id', 'char_posts.id')
+        .leftJoin('users as char_users', 'char_posts.user_id', 'char_users.id')
+    
+    if (sort === 'created') {
+        query.orderBy('t.created_at', 'desc')
+    } else {
+        query.orderBy('t.latest_post_id', 'desc')
+    }
+    
+    query.limit(perPage)
+    
+    return pool.query(query.toString()).then(res => res.rows)
 }
 
 router.get('/roleplays', async (ctx: Context) => {

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -3,7 +3,6 @@
 import Router from '@koa/router'
 import Knex from 'knex'
 const knex = Knex({ client: 'pg' })
-import { _raw } from 'pg-extra'
 import createDebug from 'debug'
 const debug = createDebug('app:search')
 // 1st
@@ -189,8 +188,8 @@ router.get('/search', async (ctx: Context) => {
     debug(query.toString())
 
     const posts = await pool
-        .many(_raw`${query.toString()}`)
-        .then(xs => xs.map(x => pre.presentPost(x)))
+        .query(query.toString())
+        .then(res => res.rows.map(x => pre.presentPost(x)))
 
     ctx.set('X-Robots-Tag', 'noindex')
 

--- a/tasks/fork_small_avatars.js
+++ b/tasks/fork_small_avatars.js
@@ -1,104 +1,104 @@
 
-// Node
-const fs = require('fs')
-// 3rd
-const { assert } = require('../server/util')
-const Uploader = require('s3-streaming-upload').Uploader
-const {sql} = require('pg-extra')
-const gm = require('gm').subClass({ imageMagick: true })
-const fetch = require('node-fetch')
-const makeQueue = require('promise-task-queue')
-// 1st
-const config = require('../server/config')
-const {pool} = require('../server/db/util')
+// // Node
+// const fs = require('fs')
+// // 3rd
+// const { assert } = require('../server/util')
+// const Uploader = require('s3-streaming-upload').Uploader
+// const {sql} = require('pg-extra')
+// const gm = require('gm').subClass({ imageMagick: true })
+// const fetch = require('node-fetch')
+// const makeQueue = require('promise-task-queue')
+// // 1st
+// const config = require('../server/config')
+// const {pool} = require('../server/db/util')
 
-//
-// This task takes every /production/:hash.:ext avatar, creates a resized
-// copy of max dimensions 32x32, and uploads it to /production/32/:hash.:ext
-//
+// //
+// // This task takes every /production/:hash.:ext avatar, creates a resized
+// // copy of max dimensions 32x32, and uploads it to /production/32/:hash.:ext
+// //
 
-const prefix = config.NODE_ENV === 'production'
-  ? 'production'
-  : 'development'
+// const prefix = config.NODE_ENV === 'production'
+//   ? 'production'
+//   : 'development'
 
-const queue = makeQueue()
+// const queue = makeQueue()
 
-queue.define('process', async (avatar) => {
-  const response = await fetch(avatar.url)
-  const mime = response.headers.get('content-type')
-  if (!['image/jpeg', 'image/gif', 'image/png', 'image/bmp'].includes(mime)) {
-    throw new Error('unexpected mime:' + mime)
-  }
-  const stream = await resize(response.body)
-  const objectName = `${prefix}/32/${avatar.hash}.${avatar.ext}`
-  const newUrl = await upload({ mime, stream, objectName })
-  console.log(`uploaded ${avatar.url}\n-> ${newUrl}`)
-}, { concurrency: 12 })
+// queue.define('process', async (avatar) => {
+//   const response = await fetch(avatar.url)
+//   const mime = response.headers.get('content-type')
+//   if (!['image/jpeg', 'image/gif', 'image/png', 'image/bmp'].includes(mime)) {
+//     throw new Error('unexpected mime:' + mime)
+//   }
+//   const stream = await resize(response.body)
+//   const objectName = `${prefix}/32/${avatar.hash}.${avatar.ext}`
+//   const newUrl = await upload({ mime, stream, objectName })
+//   console.log(`uploaded ${avatar.url}\n-> ${newUrl}`)
+// }, { concurrency: 12 })
 
-// { url, hash, ext }
-async function listAvatars () {
-  return pool.many(sql`
-    SELECT avatar_url
-    FROM users
-    WHERE avatar_url IS NOT NULL
-      AND char_length(avatar_url) > 3
-  `).then((xs) => xs.map((x) => {
-    const url = x.avatar_url
-    const [_, hash, ext] = require('url')
-      .parse(url)
-      .pathname
-      .match(new RegExp(`/${prefix}/([a-f0-9]+)\.(.+)$`))
-    if (![url, hash, ext].every(Boolean)) {
-      throw new Error('url, hash, or ext are falsey')
-    }
-    return {url, hash, ext}
-  }))
-}
+// // { url, hash, ext }
+// async function listAvatars () {
+//   return pool.many(sql`
+//     SELECT avatar_url
+//     FROM users
+//     WHERE avatar_url IS NOT NULL
+//       AND char_length(avatar_url) > 3
+//   `).then((xs) => xs.map((x) => {
+//     const url = x.avatar_url
+//     const [_, hash, ext] = require('url')
+//       .parse(url)
+//       .pathname
+//       .match(new RegExp(`/${prefix}/([a-f0-9]+)\.(.+)$`))
+//     if (![url, hash, ext].every(Boolean)) {
+//       throw new Error('url, hash, or ext are falsey')
+//     }
+//     return {url, hash, ext}
+//   }))
+// }
 
-// Returns Promise<inputStream> of resized image
-async function resize (stream) {
-  return gm(stream)
-    .resize(32, 32, '>')
-    .stream()
-}
+// // Returns Promise<inputStream> of resized image
+// async function resize (stream) {
+//   return gm(stream)
+//     .resize(32, 32, '>')
+//     .stream()
+// }
 
-async function upload ({objectName, mime, stream}) {
-  assert(typeof objectName === 'string')
-  assert(typeof mime === 'string')
-  assert(stream)
+// async function upload ({objectName, mime, stream}) {
+//   assert(typeof objectName === 'string')
+//   assert(typeof mime === 'string')
+//   assert(stream)
 
-  const uploader = new Uploader({
-    stream,
-    objectName,
-    accessKey: config.AWS_KEY,
-    secretKey: config.AWS_SECRET,
-    bucket: config.S3_AVATAR_BUCKET,
-    objectParams: {
-      'ContentType': mime,
-      'CacheControl': 'max-age=31536000' // 1 year
-    }
-  })
+//   const uploader = new Uploader({
+//     stream,
+//     objectName,
+//     accessKey: config.AWS_KEY,
+//     secretKey: config.AWS_SECRET,
+//     bucket: config.S3_AVATAR_BUCKET,
+//     objectParams: {
+//       'ContentType': mime,
+//       'CacheControl': 'max-age=31536000' // 1 year
+//     }
+//   })
 
-  return new Promise((resolve, reject) => {
-    uploader.send((err, data) => {
-      if (err) return reject(err)
-      const newAvatarUrl = data.Location
-      return resolve(newAvatarUrl)
-    })
-  })
-}
+//   return new Promise((resolve, reject) => {
+//     uploader.send((err, data) => {
+//       if (err) return reject(err)
+//       const newAvatarUrl = data.Location
+//       return resolve(newAvatarUrl)
+//     })
+//   })
+// }
 
-async function run () {
-  const avatars = await listAvatars()
+// async function run () {
+//   const avatars = await listAvatars()
 
-  avatars.forEach((avatar) => {
-    queue.push('process', avatar)
-      .catch((err) => {
-        console.error(`problem with avatar ${JSON.stringify(avatar)}`, err)
-      })
-  })
-}
+//   avatars.forEach((avatar) => {
+//     queue.push('process', avatar)
+//       .catch((err) => {
+//         console.error(`problem with avatar ${JSON.stringify(avatar)}`, err)
+//       })
+//   })
+// }
 
-run()
-.then(() => console.log('done'))
-.catch((err) => console.error(err))
+// run()
+// .then(() => console.log('done'))
+// .catch((err) => console.error(err))

--- a/tasks/migrate_avatars.js
+++ b/tasks/migrate_avatars.js
@@ -1,94 +1,94 @@
-// Node
-const zlib = require('zlib')
-const path = require('path')
-// 3rd
-const {sql} = require('pg-extra')
-const fetch = require('node-fetch')
-const Uploader = require('s3-streaming-upload').Uploader
-const promiseMap = require('promise.map')
-// 1st
-const config = require('../server/config')
-const {pool} = require('../server/db/util')
+// // Node
+// const zlib = require('zlib')
+// const path = require('path')
+// // 3rd
+// const {sql} = require('pg-extra')
+// const fetch = require('node-fetch')
+// const Uploader = require('s3-streaming-upload').Uploader
+// const promiseMap = require('promise.map')
+// // 1st
+// const config = require('../server/config')
+// const {pool} = require('../server/db/util')
 
-////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////
 
-function extToType (ext) {
-  switch (ext) {
-    case '.jpeg':
-    case '.jpg':
-      return 'image/jpeg'
-    case '.gif':
-      return 'image/gif'
-    case '.png':
-      return 'image/png'
-    case '.bmp':
-      return 'image/bmp'
-    default:
-      throw new Error('unknown ext: ' + ext)
-  }
-}
+// function extToType (ext) {
+//   switch (ext) {
+//     case '.jpeg':
+//     case '.jpg':
+//       return 'image/jpeg'
+//     case '.gif':
+//       return 'image/gif'
+//     case '.png':
+//       return 'image/png'
+//     case '.bmp':
+//       return 'image/bmp'
+//     default:
+//       throw new Error('unknown ext: ' + ext)
+//   }
+// }
 
-async function getUsersWithOldAvatarUrls () {
-  return pool.many(sql`
-    SELECT id, uname, avatar_url
-    FROM users
-    WHERE avatar_url LIKE 'https://rpguild-prod.s3.amazonaws.com/avatars/%'
-  `)
-}
+// async function getUsersWithOldAvatarUrls () {
+//   return pool.many(sql`
+//     SELECT id, uname, avatar_url
+//     FROM users
+//     WHERE avatar_url LIKE 'https://rpguild-prod.s3.amazonaws.com/avatars/%'
+//   `)
+// }
 
-async function updateUser (userId, avatarUrl) {
-  return pool.query(sql`
-    UPDATE users
-    SET avatar_url = ${avatarUrl}
-    WHERE id = ${userId}
-  `)
-}
+// async function updateUser (userId, avatarUrl) {
+//   return pool.query(sql`
+//     UPDATE users
+//     SET avatar_url = ${avatarUrl}
+//     WHERE id = ${userId}
+//   `)
+// }
 
-// Returns Promise<newAvatarUrl>
-async function upload (user) {
-  console.log('fetching url:', user.avatar_url)
-  const res = await fetch(user.avatar_url)
-  const gzip = zlib.createGzip()
-  const [_, fileName] = require('url')
-    .parse(user.avatar_url)
-    .path
-    .match(/\/avatars\/(.+)$/)
-  const contentType = extToType(path.extname(fileName))
-  console.log('content-type:', contentType)
-  const objectName = `production/${fileName}`
-  console.log('objectName:', objectName)
-  const uploader = new Uploader({
-    stream: res.body.pipe(gzip),
-    accessKey: config.AWS_KEY,
-    secretKey: config.AWS_SECRET,
-    bucket: config.S3_AVATAR_BUCKET,
-    objectName,
-    objectParams: {
-      'ContentType': contentType,
-      'CacheControl': 'max-age=31536000', // 1 year
-      'ContentEncoding': 'gzip'
-    }
-  })
-  return new Promise((resolve, reject) => {
-    uploader.send((err, data) => {
-      if (err) return reject(err)
-      const newAvatarUrl = data.Location
-      return resolve(newAvatarUrl)
-    })
-  })
-}
+// // Returns Promise<newAvatarUrl>
+// async function upload (user) {
+//   console.log('fetching url:', user.avatar_url)
+//   const res = await fetch(user.avatar_url)
+//   const gzip = zlib.createGzip()
+//   const [_, fileName] = require('url')
+//     .parse(user.avatar_url)
+//     .path
+//     .match(/\/avatars\/(.+)$/)
+//   const contentType = extToType(path.extname(fileName))
+//   console.log('content-type:', contentType)
+//   const objectName = `production/${fileName}`
+//   console.log('objectName:', objectName)
+//   const uploader = new Uploader({
+//     stream: res.body.pipe(gzip),
+//     accessKey: config.AWS_KEY,
+//     secretKey: config.AWS_SECRET,
+//     bucket: config.S3_AVATAR_BUCKET,
+//     objectName,
+//     objectParams: {
+//       'ContentType': contentType,
+//       'CacheControl': 'max-age=31536000', // 1 year
+//       'ContentEncoding': 'gzip'
+//     }
+//   })
+//   return new Promise((resolve, reject) => {
+//     uploader.send((err, data) => {
+//       if (err) return reject(err)
+//       const newAvatarUrl = data.Location
+//       return resolve(newAvatarUrl)
+//     })
+//   })
+// }
 
-async function run () {
-  const users = await getUsersWithOldAvatarUrls()
-  console.log('users:', users.length)
-  return promiseMap(users, async (user) => { 
-    const newAvatarUrl = await upload(user)
-    await updateUser(user.id, newAvatarUrl)
-    console.log('[saved] newAvatarUrl:', newAvatarUrl, user.uname)
-  }, 8)
-}
+// async function run () {
+//   const users = await getUsersWithOldAvatarUrls()
+//   console.log('users:', users.length)
+//   return promiseMap(users, async (user) => { 
+//     const newAvatarUrl = await upload(user)
+//     await updateUser(user.id, newAvatarUrl)
+//     console.log('[saved] newAvatarUrl:', newAvatarUrl, user.uname)
+//   }, 8)
+// }
 
 
-run()
-  .then(() => console.log('done'))
-  .catch((err) => console.error(err))
+// run()
+//   .then(() => console.log('done'))
+//   .catch((err) => console.error(err))


### PR DESCRIPTION
this is a self-inflicted injury from years ago when i thought it would be a good idea to create a library that mutates `pg` so that i could use a `sql` tag to write sql.

though my heart was in the right place: i

if i'm going to add a sql template tag so i can write code like this: `pg.query(sql``... where id = ${id}``)`, then it better be impossible to accidentally forget to use the sql tag.