### PR TITLE
Remove outdated "under construction" message from visitor messages tab

### DIFF
--- a/views/show_user_visitor_messages.html
+++ b/views/show_user_visitor_messages.html
@@ -15,10 +15,6 @@
     }
   </style>
 
-  <p class="text-muted" style="margin-top: 10px;">
-    <span class="label label-info">Note</span> This feature is new and under construction
-  </p>
-
   <a name="vms"></a>
 
   {% if ctx.can(ctx.currUser, 'CREATE_VM') %}


### PR DESCRIPTION
Fixes #226

Removes the "This feature is new and under construction" message from the visitor message tab, as requested. The visitor message system has been stable for years and is no longer under construction.

Generated with [Claude Code](https://claude.ai/code)