### PR TITLE
Remove outdated BBCode announcement text

### DIFF
--- a/views/partials/bbcode_cheatsheet.html
+++ b/views/partials/bbcode_cheatsheet.html
@@ -9,13 +9,6 @@
 
   <div id="cheatsheet-body" style="display: none">
 
-    <!-- Announcements -->
-    <hr>
-    <h5>BBCode Announcements</h5>
-    <ul>
-      <li style="color: #3BB878;">[March 8] Added <code>[hr]</code> tag for creating horizontal lines. Useful as a generic separator for organizing your posts.</li>
-    </ul>
-    <hr>
 
     <!-- Smilies -->
 


### PR DESCRIPTION
Fixes #228

Removed the outdated BBCode announcement section about the [hr] tag from the BBCode cheatsheet.

🤖 Generated with [Claude Code](https://claude.ai/code)