### PR TITLE
fix: add hyperlink to user avatars in private messages

### DIFF
--- a/views/show_convo.html
+++ b/views/show_convo.html
@@ -114,7 +114,9 @@
               {% if post.user.avatar_url %}
                 <div class="post-avatar"
                      style="margin-top: 10px;">
-                  <img src="{{ post.user.avatar_url}}" alt="Avatar of {{ post.user.uname }}">
+                  <a href="{{ post.user.url }}">
+                    <img src="{{ post.user.avatar_url}}" alt="Avatar of {{ post.user.uname }}">
+                  </a>
                 </div>
               {% endif %}
 


### PR DESCRIPTION
Avatars in private conversations now link to user profiles,
matching the behavior in normal topics.

Fixes #230

Generated with [Claude Code](https://claude.ai/code)