### PR TITLE
fix: remove responsive wrapper from table bbcode

### DIFF
--- a/server/bbcode.js
+++ b/server/bbcode.js
@@ -861,12 +861,12 @@ var XBBCODE = (function() {
         table: {
             openTag: function(params, content) {
                 if (params && params.slice(1) === 'bordered')
-                    return '<div class="table-responsive"><table class="bb-table table table-bordered">'
-                return '<div class="table-responsive"><table class="bb-table table">'
+                    return '<table class="bb-table table table-bordered">'
+                return '<table class="bb-table table">'
             },
             closeTag: function(params, content) {
                 isFirstTableRow = true
-                return '</table></div>'
+                return '</table>'
             },
             // restrictChildrenTo: ["tbody","thead", "tfoot", "tr"]
             restrictChildrenTo: ['row'],


### PR DESCRIPTION
Fixes #229

Tables no longer generate the Bootstrap table-responsive div wrapper that adds horizontal scrolling. The table element is now rendered directly without the wrapper.

Generated with [Claude Code](https://claude.ai/code)