### PR TITLE
Create bulk versions of notifications db fns

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1987,11 +1987,15 @@ export async function createSubNotificationsBulk(
     assert(Number.isInteger(toUserId));
   });
 
-  // Method 1: Using UNNEST (PostgreSQL arrays)
   const fromUserIds = notifications.map((n) => n.fromUserId);
   const toUserIds = notifications.map((n) => n.toUserId);
   const topicIds = notifications.map((n) => n.topicId);
   const metas = notifications.map((n) => ({ [n.postType]: true }));
+
+  // Ensure all the unnest arrays have the same length
+  assert(fromUserIds.length === toUserIds.length);
+  assert(fromUserIds.length === topicIds.length);
+  assert(fromUserIds.length === metas.length);
 
   return pgClient.query(
     `
@@ -2034,6 +2038,10 @@ export async function createConvoNotificationsBulk(
   const fromUserIds = notifications.map((n) => n.from_user_id);
   const toUserIds = notifications.map((n) => n.to_user_id);
   const convoIds = notifications.map((n) => n.convo_id);
+
+  // Ensure all the unnest arrays have the same length
+  assert(fromUserIds.length === toUserIds.length);
+  assert(fromUserIds.length === convoIds.length);
 
   return pgClient
     .query<DbNotification>(
@@ -2085,6 +2093,10 @@ export async function createPmNotificationsBulk(
   const toUserIds = notifications.map((n) => n.to_user_id);
   const convoIds = notifications.map((n) => n.convo_id);
 
+  // Ensure all the unnest arrays have the same length
+  assert(fromUserIds.length === toUserIds.length);
+  assert(fromUserIds.length === convoIds.length);
+
   return pgClient
     .query<DbNotification>(
       `
@@ -2129,6 +2141,10 @@ export async function createTopLevelVmNotificationsBulk(
   const toUserIds = notifications.map((n) => n.to_user_id);
   const vmIds = notifications.map((n) => n.vm_id);
 
+  // Ensure all the unnest arrays have the same length
+  assert(fromUserIds.length === toUserIds.length);
+  assert(fromUserIds.length === vmIds.length);
+
   return pgClient
     .query<DbNotification>(
       `
@@ -2172,6 +2188,10 @@ export async function createReplyVmNotificationsBulk(
   const fromUserIds = notifications.map((n) => n.from_user_id);
   const toUserIds = notifications.map((n) => n.to_user_id);
   const vmIds = notifications.map((n) => n.vm_id);
+
+  // Ensure all the unnest arrays have the same length
+  assert(fromUserIds.length === toUserIds.length);
+  assert(fromUserIds.length === vmIds.length);
 
   return pgClient
     .query<DbNotification>(
@@ -2460,6 +2480,11 @@ export async function createMentionNotificationsBulk(
   const topicIds = notifications.map((n) => n.topic_id);
   const postIds = notifications.map((n) => n.post_id);
 
+  // Ensure all the unnest arrays have the same length
+  assert(fromUserIds.length === toUserIds.length);
+  assert(fromUserIds.length === topicIds.length);
+  assert(fromUserIds.length === postIds.length);
+
   return pgClient
     .query<{ id: number }>(
       `
@@ -2541,6 +2566,11 @@ export async function createQuoteNotificationsBulk(
   const toUserIds = notifications.map((n) => n.to_user_id);
   const topicIds = notifications.map((n) => n.topic_id);
   const postIds = notifications.map((n) => n.post_id);
+
+  // Ensure all the unnest arrays have the same length
+  assert(fromUserIds.length === toUserIds.length);
+  assert(fromUserIds.length === topicIds.length);
+  assert(fromUserIds.length === postIds.length);
 
   return pgClient
     .query<{ id: number }>(

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1997,8 +1997,9 @@ export async function createSubNotificationsBulk(
   assert(fromUserIds.length === topicIds.length);
   assert(fromUserIds.length === metas.length);
 
-  return pgClient.query(
-    `
+  return pgClient
+    .query<DbNotification>(
+      `
     INSERT INTO notifications (type, from_user_id, to_user_id, topic_id, meta, count)
     SELECT 
       'TOPIC_SUB',
@@ -2011,9 +2012,11 @@ export async function createSubNotificationsBulk(
       DO UPDATE
       SET count = COALESCE(notifications.count, 0) + 1,
           meta = notifications.meta || EXCLUDED.meta
+    RETURNING *
     `,
-    [fromUserIds, toUserIds, topicIds, metas],
-  );
+      [fromUserIds, toUserIds, topicIds, metas],
+    )
+    .then((res) => res.rows);
 }
 
 // Users receive this when someone starts a convo with them

--- a/server/db/revs.ts
+++ b/server/db/revs.ts
@@ -1,14 +1,13 @@
 // 3rd
 import assert from "assert";
 // 1st
-import { pool, maybeOneRow } from "./util";
-import pg from "pg";
+import { pool, maybeOneRow, PgClientInTransaction } from "./util";
 
 ////////////////////////////////////////////////////////////
 
 // Reason is optional
 export async function insertPostRev(
-  client: pg.PoolClient,
+  pgClient: PgClientInTransaction,
   userId: number,
   postId: number,
   markup: string,
@@ -21,7 +20,7 @@ export async function insertPostRev(
   assert(typeof html === "string");
   assert(!reason || typeof reason === "string");
 
-  return client.query(
+  return pgClient.query(
     `
     INSERT INTO post_revs (user_id, post_id, markup, html, length, reason)
     VALUES (

--- a/server/db/subscriptions.ts
+++ b/server/db/subscriptions.ts
@@ -3,20 +3,23 @@ import assert from "assert";
 // import createDebug from 'debug';
 // const debug = createDebug('app:db:subscriptions')
 // 1st
-import { pool } from "./util";
+import { PgClientInTransaction, pool } from "./util";
 import * as db from ".";
 
 ////////////////////////////////////////////////////////////
 
 // Gets non-archived subs
-export const listActiveSubscribersForTopic = async function (topicId) {
+export async function listActiveSubscribersForTopic(
+  pgClient: PgClientInTransaction,
+  topicId: number,
+) {
   assert(Number.isInteger(topicId));
 
-  return pool
-    .query(
+  return pgClient
+    .query<{ user_id: number }>(
       `
     SELECT
-      u.id
+      u.id as user_id
     FROM users u
     JOIN topic_subscriptions ts ON u.id = ts.user_id
     WHERE ts.topic_id = $1
@@ -25,7 +28,7 @@ export const listActiveSubscribersForTopic = async function (topicId) {
       [topicId],
     )
     .then((res) => res.rows);
-};
+}
 
 ////////////////////////////////////////////////////////////
 

--- a/server/db/unames.ts
+++ b/server/db/unames.ts
@@ -100,12 +100,18 @@ export const latestUnameChanges = async function (limit = 10) {
 
 ////////////////////////////////////////////////////////////
 
-export const changeUname = async function ({
+export async function changeUname({
   userId,
   changedById,
   oldUname,
   newUname,
   recycle = false,
+}: {
+  userId: number;
+  changedById: number;
+  oldUname: string;
+  newUname: string;
+  recycle?: boolean;
 }) {
   debug(`[changeUname] oldUname=%j, newUname=%j`, oldUname, newUname);
   assert(Number.isInteger(userId));
@@ -163,6 +169,6 @@ export const changeUname = async function ({
       )
       .then(maybeOneRow);
   });
-};
+}
 
 ////////////////////////////////////////////////////////////

--- a/server/dbtypes.ts
+++ b/server/dbtypes.ts
@@ -86,3 +86,18 @@ export type DbTopic = {
   banned_ids: number[];
   join_status: string;
 };
+
+export type DbVm = {
+  id: number;
+  from_user_id: number;
+  to_user_id: number;
+  markup: string;
+  html: string;
+  parent_vm_id: number | null;
+};
+
+export type DbTag = {
+  id: number;
+  name: string;
+  tag_group_id: number;
+};

--- a/server/dbtypes.ts
+++ b/server/dbtypes.ts
@@ -1,0 +1,88 @@
+// A best effort attempt to represent db columns with typescript types
+// Will extend as we go
+
+export type DbUser = {
+  id: number;
+  slug: string;
+  uname: string;
+  email: string;
+  email_verified: boolean;
+  eflags: number;
+  created_at: Date;
+  updated_at: Date;
+  bio_markup: string;
+  bio_html: string;
+  sig_html: string;
+  sig: string;
+  avatar_url: string;
+  custom_title: string;
+  is_nuked: boolean;
+  digest: string; // should be bytea jeez
+  posts_count: number;
+  last_online_at: Date;
+  role: string;
+  hide_sigs: boolean;
+  hide_avatars: boolean;
+  is_ghost: boolean;
+  is_grayscale: boolean;
+  force_device_width: boolean;
+  trophy_count: number;
+  active_trophy_id: number | null;
+  current_status_id: number | null;
+
+  // Sometimes has nested fields
+  nuked_by?: DbUser | void;
+  approved_by?: DbUser | void;
+};
+
+export type DbNotification = {
+  id: number;
+  from_user_id: number;
+  to_user_id: number;
+};
+
+export type DbConvo = {
+  id: number;
+  user_id: number;
+  title: string;
+  url: string;
+  pms_count: number;
+  created_at: Date;
+
+  // Sometimes has nested fields
+  user?: DbUser;
+  participants?: DbUser[];
+  pms?: DbPm[];
+  latest_user?: DbUser;
+  latest_pm?: DbPm;
+};
+
+export type DbPm = {
+  id: number;
+  convo_id: number;
+  user_id: number;
+  ip_address: string;
+  markup: string;
+  html: string;
+  idx: number;
+};
+
+export type DbSession = {
+  id: number;
+  user_id: number;
+  ip_address: string;
+  user_agent: string;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export type DbTopic = {
+  id: number;
+  title: string;
+  slug: string;
+  forum_id: number;
+  user_id: number;
+  co_gm_ids: number[];
+  banned_ids: number[];
+  join_status: string;
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -1078,8 +1078,8 @@ router.post(
           ctx.request.body.markup.length,
       );
 
-    var postType = ctx.vals["post-type"];
-    var topic = await db.findTopic(topicId);
+    const postType = ctx.vals["post-type"];
+    const topic = await db.findTopic(topicId);
     ctx.assert(topic, 404);
     topic.mods = cache3.get("forum-mods")[topic.forum_id] || [];
     ctx.assertAuthorized(ctx.currUser, "CREATE_POST", topic);
@@ -1090,11 +1090,11 @@ router.post(
     }
 
     // Render the bbcode
-    var html = bbcode(ctx.vals.markup);
+    const html = bbcode(ctx.vals.markup);
 
     const { post, mentionNotificationsCount, quoteNotificationsCount } =
       await withPgPoolTransaction(pool, async (pgClient) => {
-        var post = await db
+        const post = await db
           .createPost(pgClient, {
             userId: ctx.currUser.id,
             ipAddress: ctx.request.ip,

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -37,10 +37,10 @@ router.post("/admin/users/merge", async (ctx: Context) => {
 
   const mainUser = await db
     .findUserBySlug(ctx.vals["main-slug"])
-    .then(pre.presentUser);
+    .then((user) => pre.presentUser(user));
   const huskUser = await db
     .findUserBySlug(ctx.vals["husk-slug"])
-    .then(pre.presentUser);
+    .then((user) => pre.presentUser(user));
 
   ctx
     .validateBody("main-slug")
@@ -50,14 +50,14 @@ router.post("/admin/users/merge", async (ctx: Context) => {
     .check(!!huskUser, "user not found for husk slug");
 
   await db.admin.mergeUsers({
-    mainId: mainUser.id,
-    huskId: huskUser.id,
+    mainId: mainUser!.id,
+    huskId: huskUser!.id,
   });
 
   ctx.flash = {
-    message: ["success", `${huskUser.uname} merged into ${mainUser.uname}`],
+    message: ["success", `${huskUser!.uname} merged into ${mainUser!.uname}`],
   };
-  ctx.redirect(mainUser.url);
+  ctx.redirect(mainUser!.url);
 });
 
 ////////////////////////////////////////////////////////////

--- a/sql/4-better-notif-indexes.sql
+++ b/sql/4-better-notif-indexes.sql
@@ -1,3 +1,10 @@
+-- add updated_at column to notifications table
+
+alter table notifications
+add column updated_at timestamptz not null default now();
+-- Update existing rows to set updated_at = created_at
+UPDATE notifications SET updated_at = created_at;
+
 -- Ensure that a user can only have one notification for each type at a time
 
 -- One MENTION per post (we don't create mentions for PMs)

--- a/sql/4-better-notif-indexes.sql
+++ b/sql/4-better-notif-indexes.sql
@@ -1,0 +1,47 @@
+-- Ensure that a user can only have one notification for each type at a time
+
+-- One MENTION per post (we don't create mentions for PMs)
+create unique index notifications_mention_unique on notifications (to_user_id, post_id) 
+  where type = 'MENTION';
+-- and post_id is not null; (post_id is always set if we create a mention)
+
+-- One QUOTE per post
+create unique index notifications_quote_unique on notifications (to_user_id, post_id) 
+  where type = 'QUOTE';
+-- and post_id is not null; (post_id is always set if we create a quote)
+
+-- One TOPIC_SUB per topic
+create unique index notifications_topic_sub_unique on notifications (to_user_id, topic_id) 
+  where type = 'TOPIC_SUB';
+-- and topic_id is not null; (topic_id is always set if we create a topic sub)
+
+-- One CONVO per convo
+create unique index notifications_convo_unique on notifications (to_user_id, convo_id) 
+  where type = 'CONVO';
+-- and convo_id is not null; (convo_id is always set if we create a convo)
+
+-- One RATING per post (PMs can't have ratings)
+-- We'd have to change this if we allow ratings on PMs which is a reasonable possibility
+create unique index notifications_rating_unique on notifications (to_user_id, post_id) 
+  where type = 'RATING';
+-- and post_id is not null; (post_id is always set if we create a rating)
+
+-- One TOPLEVEL_VM per user per VM (TODO: Verify this is correct)
+-- CREATE UNIQUE INDEX notifications_toplevel_vm_unique
+-- ON notifications (to_user_id, vm_id) WHERE type = 'TOPLEVEL_VM';
+
+-- One REPLY_VM per user per VM (TODO: Verify this is correct)
+-- CREATE UNIQUE INDEX notifications_reply_vm_unique
+-- ON notifications (to_user_id, vm_id) WHERE type = 'REPLY_VM';
+
+--------------------------------
+-- Delete obsolete indexes
+--------------------------------
+
+-- Remove UNIQUE (to_user_id, convo_id) constraint
+-- obsoleted by new index notifications_convo_unique
+ALTER TABLE notifications
+DROP CONSTRAINT notifications_to_user_id_convo_id_key;
+
+-- TODO: Must remove its use from ON CONFLICT clause in db.createVmNotification
+-- DROP INDEX unique_to_user_id_vm_id;

--- a/sql/4-better-notif-indexes.sql
+++ b/sql/4-better-notif-indexes.sql
@@ -26,13 +26,17 @@ create unique index notifications_rating_unique on notifications (to_user_id, po
   where type = 'RATING';
 -- and post_id is not null; (post_id is always set if we create a rating)
 
--- One TOPLEVEL_VM per user per VM (TODO: Verify this is correct)
--- CREATE UNIQUE INDEX notifications_toplevel_vm_unique
--- ON notifications (to_user_id, vm_id) WHERE type = 'TOPLEVEL_VM';
+-- One TOPLEVEL_VM per user (this is created when a user creates a new VM on their page)
+-- I don't think we create notifications when a user replies to a VM on their page that wasn't
+-- created by them.
+DROP INDEX IF EXISTS notifications_toplevel_vm_unique;
 
--- One REPLY_VM per user per VM (TODO: Verify this is correct)
--- CREATE UNIQUE INDEX notifications_reply_vm_unique
--- ON notifications (to_user_id, vm_id) WHERE type = 'REPLY_VM';
+CREATE UNIQUE INDEX notifications_toplevel_vm_unique ON notifications (to_user_id, vm_id) WHERE type = 'TOPLEVEL_VM';
+
+-- One REPLY_VM per user per VM (everyone someone replies to their VM, the count++)
+DROP INDEX IF EXISTS notifications_reply_vm_unique;
+
+CREATE UNIQUE INDEX notifications_reply_vm_unique ON notifications (to_user_id, vm_id) WHERE type = 'REPLY_VM';
 
 --------------------------------
 -- Delete obsolete indexes
@@ -44,4 +48,4 @@ ALTER TABLE notifications
 DROP CONSTRAINT notifications_to_user_id_convo_id_key;
 
 -- TODO: Must remove its use from ON CONFLICT clause in db.createVmNotification
--- DROP INDEX unique_to_user_id_vm_id;
+DROP INDEX unique_to_user_id_vm_id;


### PR DESCRIPTION
Requires db migration:

- [ ] run the create index queries in sql/4-better-notif-indexes.sql on production db
- [ ] deploy app code
- [ ] run the delete index queries in sql/4-better-notif-indexes.sql on production db

Right now, creating N notifications results in N sequential trips to the database.

This PR changes them in to bulk fns that can create N notifications in one db query.