### PR TITLE
fix: add missing image URL in presentImage function

### DIFF
--- a/server/presenters.ts
+++ b/server/presenters.ts
@@ -308,6 +308,11 @@ export const presentImage = function (x) {
 
   presentUser(x.user);
 
+  // Set the URL for viewing individual images
+  if (x.user) {
+    x.url = `/users/${x.user.slug}/images/${x.id}`;
+  }
+
   // Legacy image url: https://s3.amazonaws.com/img.roleplayerguild.com/prod/users/0001999e-ac95-468b-a526-0fd8ffc8591b.png
   // New image url: https://img.roleplayerguild.com/prod/users/0001999e-ac95-468b-a526-0fd8ffc8591b.avif
 


### PR DESCRIPTION
The presentImage function was not setting the URL property for images,
which caused links to individual images to be broken in albums and
image lists. This adds the missing x.url property using the pattern
/users/:user_slug/images/:image_id to match the existing route.

Fixes #244

Generated with [Claude Code](https://claude.ai/code)