### PR TITLE
Fix Internal Server Error when deleting friends

### DIFF
--- a/server/routes/friendships.ts
+++ b/server/routes/friendships.ts
@@ -29,8 +29,15 @@ router.post("/me/friendships", async (ctx: Context) => {
 
   let redirectTo;
   if (typeof ctx.query["redirect-to"] === "string") {
-    const parsed = new URL(decodeURIComponent(ctx.query["redirect-to"]));
-    redirectTo = parsed.pathname;
+    try {
+      const decodedUrl = decodeURIComponent(ctx.query["redirect-to"]);
+      // Handle relative URLs by providing a base URL
+      const parsed = new URL(decodedUrl, `http://localhost`);
+      redirectTo = parsed.pathname;
+    } catch (err) {
+      // If URL parsing fails, ignore the redirect parameter
+      console.warn('Failed to parse redirect URL:', err);
+    }
   }
 
   // update db


### PR DESCRIPTION
Fixes #249

This PR fixes the Internal Server Error that occurs when users attempt to delete friends from the Friends page.

## Changes
- Added proper error handling for URL parsing in the friendships route
- Provided a base URL to handle relative paths correctly
- Wrapped URL parsing in try-catch to prevent crashes
- Log warnings when URL parsing fails instead of throwing

## Root Cause
The error was caused by malformed redirect URLs (with trailing periods or other invalid characters) that would cause the URL constructor to throw an error, resulting in an unhandled exception.

Generated with [Claude Code](https://claude.ai/code)